### PR TITLE
Add ASTER support for species-tree reconstruction

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "ASTRAL"]
 	path = ASTRAL
 	url = https://github.com/smirarab/ASTRAL.git
+[submodule "ASTER"]
+	path = ASTER
+	url = https://github.com/chaoszhang/ASTER.git

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See the wiki (<https://github.com/BenoitMorel/ParGenes/wiki/Running-ParGenes>).
 Additinal options are `--use-aster`, `--aster-bin`, and
 `--aster-global-parameters`.  The `--aster-bin` takes an option, which is
 either the name or path to any of the ASTER-astral binaries (`astral`,
-astral-hybrid`, or `astral-pro`), or the path to a local copy of any of these.
+`astral-hybrid`, or `astral-pro`), or the path to a local copy of any of these.
 Additional arguments to any of these programs can be passed by using the option
 `--aster-global-parameters`, which takes a file as input.  See
 <https://github.com/chaoszhang/ASTER> for descriptions of these software.

--- a/README.md
+++ b/README.md
@@ -1,72 +1,70 @@
-# ParGenes 
+# ParGenes
 
 A massively parallel tool for model selection and tree inference on thousands of genes
 
 ## Features
 
-ParGenes is a parallel tool that takes as input a set of multiple sequence alignments (typically from different genes) and infers their corresponding phylogenetic trees. 
+ParGenes is a parallel tool that takes as input a set of multiple sequence alignments (typically from different genes) and infers their corresponding phylogenetic trees.
 
 ParGenes supports the following features:
+
 * best-fit model selection with ModelTest
 * phylogenetic tree inference with RAxML-NG (with customizable number of starting trees and bootstrap trees)
 * automatic parallelization to make the best use of the available computing cores
-* checkpointing: ParGenes can be restarted without effort after an interuption
+* check pointing: ParGenes can be restarted without effort after an interruption
 * error reporting for the MSAs that fail to be treated
 * options to customize the tree inference parameters
-* optional call to ASTRAL to infer a species tree from the inferred phylogenetic trees
+* optional call to ASTRAL/ASTER to infer a species tree from the inferred phylogenetic trees
 
 ## Requirement
+
 * Linux or MacOS
-* gcc 5.0 or > 
+* gcc 5.0 or >
 * CMake 3.6 or >
-* Either MPI or OpenMP. MPI for multiple nodes parallelization (clusters).
+* Either MPI or OpenMP. MPI for multiple nodes parallelization (clusters)
 
 ## Installation
 
-(Please note that, on linux, you can also install through [`bioconda`](https://anaconda.org/bioconda/pargenes))
+(Please note that, on Linux, you can also install through [`bioconda`](https://anaconda.org/bioconda/pargenes))
 
-
-Please use git,  and clone with --recursive!!!
+Please use `git`, and clone with `--recursive`!!!
 
 ```
 git clone --recursive https://github.com/BenoitMorel/ParGenes.git
 ```
 
 To build the sources:
+
 ```
 ./install.sh
 ```
 
-
 To parallelize the compilation with 10 cores:
+
 ```
 ./install.sh 10
 ```
 
-
 ## Updating the repository
 
-Instead of using:
-``` git pull ```
-please use:
-```./gitpull.sh```
+Instead of using: `git pull`, please use: `./gitpull.sh`.
 
-Rational: we use git submodule, and `git pull` might not be enough to update all the changes. The `gitpull.sh` will update all the changes properly.
+Rational: we use git submodules, and `git pull` might not be enough to update all the changes.
+The `gitpull.sh` will update all the changes properly.
 
 ## Running
 
-See the wiki (https://github.com/BenoitMorel/ParGenes/wiki/Running-ParGenes)
+See the wiki (<https://github.com/BenoitMorel/ParGenes/wiki/Running-ParGenes>)
 
 ## Documentation and Support
 
 Documentation: in the [github wiki](https://github.com/BenoitMorel/ParGenes/wiki).
 
-Also please check the online help with `python3 pargenes/pargenes.py --help`
+Also please check the online help with `python3 pargenes/pargenes.py --help`.
 
 A suggestion, a bug to report, a question? Please use the [RAxML google group](https://groups.google.com/forum/#!forum/raxml).
 
-
 ## Citing
 
-Before citing ParGenes, please make sure you read https://github.com/BenoitMorel/ParGenes/wiki/Citation 
+Before citing ParGenes, please make sure you read <https://github.com/BenoitMorel/ParGenes/wiki/Citation>.
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ ParGenes is a parallel tool that takes as input a set of multiple sequence align
 
 ParGenes supports the following features:
 
-* best-fit model selection with ModelTest
-* phylogenetic tree inference with RAxML-NG (with customizable number of starting trees and bootstrap trees)
+* best-fit model selection with [ModelTest-NG](https://github.com/ddarriba/modeltest)
+* phylogenetic tree inference with [RAxML-NG](https://github.com/amkozlov/raxml-ng) (with customizable number of starting trees and bootstrap trees)
 * automatic parallelization to make the best use of the available computing cores
 * check pointing: ParGenes can be restarted without effort after an interruption
 * error reporting for the MSAs that fail to be treated
 * options to customize the tree inference parameters
-* optional call to ASTRAL/ASTER to infer a species tree from the inferred phylogenetic trees
+* optional call to [ASTRAL](https://github.com/smirarab/ASTRAL)/[ASTER](https://github.com/chaoszhang/ASTER) to infer a species tree from the inferred phylogenetic trees
 
 ## Requirement
 
@@ -54,7 +54,7 @@ The `gitpull.sh` will update all the changes properly.
 
 ## Running
 
-See the wiki (<https://github.com/BenoitMorel/ParGenes/wiki/Running-ParGenes>)
+See the wiki (<https://github.com/BenoitMorel/ParGenes/wiki/Running-ParGenes>).
 
 ## Documentation and Support
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,18 @@ The `gitpull.sh` will update all the changes properly.
 
 See the wiki (<https://github.com/BenoitMorel/ParGenes/wiki/Running-ParGenes>).
 
-**Run with ASTER:**
+#### Run with ASTER
 
-Additinal options are `--use-aster`, `--aster-bin`, and
-`--aster-global-parameters`.  The `--aster-bin` takes an option, which is
-either the name or path to any of the ASTER-astral binaries (`astral`,
-`astral-hybrid`, or `astral-pro`), or the path to a local copy of any of these.
-Additional arguments to any of these programs can be passed by using the option
-`--aster-global-parameters`, which takes a file as input.  See
-<https://github.com/chaoszhang/ASTER> for descriptions of these software.
+As an alternative to the default ASTRAL III software, the newer species-tree
+implementations from ASTER can be used. Specifically, the (ASTER) programs
+`astral`, `astral-hybrid` and `astral-pro` are made available.  The added
+options for pargenes are:
+
+- `--use-aster`  Use ASTER instead of ASTRAL. Note: should not be combined with `--use-astral`.
+- `--aster-bin <name or path>`  Name or path to programs `astral`, `astral-hybrid`, or `astral-pro`.
+- `--aster-global-parameters <text file>` Pass extra parameters to any of the chosen ASTER programs in a text file.
+
+See <https://github.com/chaoszhang/ASTER> for more description of the ASTER implementations.
 
 ## Documentation and Support
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ ParGenes supports the following features:
 * options to customize the tree inference parameters
 * optional call to [ASTRAL](https://github.com/smirarab/ASTRAL)/[ASTER](https://github.com/chaoszhang/ASTER) to infer a species tree from the inferred phylogenetic trees
 
-## Requirement
+## Requirements
 
 * Linux or MacOS
 * gcc 5.0 or >
@@ -27,23 +27,25 @@ ParGenes supports the following features:
 
 (Please note that, on Linux, you can also install through [`bioconda`](https://anaconda.org/bioconda/pargenes))
 
-Please use `git`, and clone with `--recursive`!!!
+Please use `git`, and clone with `--recursive`!
 
-```
-git clone --recursive https://github.com/BenoitMorel/ParGenes.git
-```
+    $ git clone --recursive https://github.com/BenoitMorel/ParGenes.git
 
 To build the sources:
 
-```
-./install.sh
-```
+    $ ./install.sh
 
 To parallelize the compilation with 10 cores:
 
-```
-./install.sh 10
-```
+    $ ./install.sh 10
+
+**To install with ASTER capacity, use the following:**
+
+    $ git clone --recurse-submodules https://github.com/nylander/ParGenes.git
+    $ cd ParGenes
+    $ git checkout aster
+    $ git submodule update --init --recursive
+    $ ./install.sh
 
 ## Updating the repository
 
@@ -55,6 +57,16 @@ The `gitpull.sh` will update all the changes properly.
 ## Running
 
 See the wiki (<https://github.com/BenoitMorel/ParGenes/wiki/Running-ParGenes>).
+
+**Run with ASTER:**
+
+Additinal options are `--use-aster`, `--aster-bin`, and
+`--aster-global-parameters`.  The `--aster-bin` takes an option, which is
+either the name or path to any of the ASTER-astral binaries (`astral`,
+astral-hybrid`, or `astral-pro`), or the path to a local copy of any of these.
+Additional arguments to any of these programs can be passed by using the option
+`--aster-global-parameters`, which takes a file as input.  See
+<https://github.com/chaoszhang/ASTER> for descriptions of these software.
 
 ## Documentation and Support
 

--- a/checker.sh
+++ b/checker.sh
@@ -1,24 +1,33 @@
 
-check_file_exists()
-  if [ -f $1 ]
+check_file_exists() {
+  if [ -x "$1" ]
   then
     echo "$1 exists... OK!"
   else
     echo "ERROR: $1 does not exist"
     exit 1
   fi
+}
 
 bindir="pargenes/pargenes_binaries"
 
 echo "Running checker.sh..."
+
 if [[ "$OSTYPE" == "darwin"* ]]; then
   echo "Not checking .so files... OK"
 else
   check_file_exists "$bindir/raxml-ng-mpi.so"
   check_file_exists "$bindir/modeltest-ng-mpi.so"
 fi
+
 check_file_exists "$bindir/raxml-ng"
 check_file_exists "$bindir/modeltest-ng"
 check_file_exists "$bindir/mpi-scheduler"
+check_file_exists "$bindir/astral.jar"
+check_file_exists "$bindir/lib"
+check_file_exists "$bindir/astral"
+check_file_exists "$bindir/astral-hybrid"
+check_file_exists "$bindir/astral-pro"
+
 echo "End of checks... No error detected!"
 

--- a/install.sh
+++ b/install.sh
@@ -1,87 +1,97 @@
 #!/bin/bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 bindir="$DIR/pargenes/pargenes_binaries"
 echo "Running from $DIR"
 
 install() {
   echo "cp -r $1 $bindir"
-  cp -r $1 $bindir
+  cp -r $1 "$bindir"
 }
 
 build_mpi_scheduler() {
   echo "*********************************"
   echo "** Installing mpi_scheduler... **"
   echo "*********************************"
-  cd MPIScheduler
+  cd MPIScheduler || exit
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake .. || exit 1
-  make -j $1 || exit 1
-  cd ../..
+  make -j "$1" || exit 1
+  cd ../.. || exit
 }
 
 build_raxml_lib() {
   echo "************************************"
   echo "** Installing raxml-ng library ...**"
   echo "************************************"
-  cd raxml-ng
+  cd raxml-ng || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake -DUSE_TERRAPHAST=OFF -DUSE_MPI=ON -DBUILD_AS_LIBRARY=ON .. || exit 1
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_raxml_exec() {
   echo "***************************************"
   echo "** Installing raxml-ng executable ...**"
   echo "***************************************"
-  cd raxml-ng
+  cd raxml-ng || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake -DUSE_TERRAPHAST=OFF -DUSE_MPI=OFF -DBUILD_AS_LIBRARY=OFF .. || exit 1
   cmake .. || exit 1
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_modeltest_lib() {
   echo "******************************************"
   echo "** Installing model-test-ng library ... **"
   echo "******************************************"
-  cd modeltest
+  cd modeltest || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake -DUSE_MPI=ON -DBUILD_AS_LIBRARY=ON .. || exit 1
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_modeltest_exec() {
   echo "******************************************"
   echo "** Installing model-test-ng executable ... **"
   echo "******************************************"
-  cd modeltest
+  cd modeltest || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   if [[ "$OSTYPE" == "darwin"* ]]; then
     cmake -DUSE_MPI=OFF .. || exit 1
   else
     cmake -DUSE_MPI=OFF -DBUILD_AS_LIBRARY=OFF -DUSE_LIBPLL_CMAKE=ON .. || exit 1
   fi
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_astral() {
   echo "******************************************"
   echo "** Installing ASTRAL...                 **"
   echo "******************************************"
-  cd ASTRAL
-  unzip -o *.zip
-  cd Astral
+  cd ASTRAL || exit 1
+  unzip -o ./*.zip
+  cd Astral || exit 1
   mv astral.*.jar astral.jar
-  cd ../../
+  cd ../../ || exit 1
+}
+
+build_aster() {
+  echo "******************************************"
+  echo "** Installing ASTER...                 **"
+  echo "******************************************"
+  cd ASTER || exit 1
+  make -j "$1" || exit 1
+  cd .. || exit 1
 }
 
 print_no_recursive_warning() {
@@ -100,10 +110,10 @@ check_recursive() {
 finish_install() {
   echo ""
   echo "Copying all binaries into $bindir"
-  mkdir -p $bindir
+  mkdir -p "$bindir"
   install "MPIScheduler/build/mpi-scheduler"
   install "raxml-ng/bin/raxml-ng"
-  install "modeltest/bin/modeltest-ng" 
+  install "modeltest/bin/modeltest-ng"
   if [[ "$OSTYPE" == "darwin"* ]]; then
     echo "MacOS install, skipping dynamic libraries installation"
   else
@@ -112,6 +122,7 @@ finish_install() {
   fi
   install "ASTRAL/Astral/astral.jar"
   install "ASTRAL/Astral/lib"
+  install "ASTER/bin/bin"
   echo ""
 }
 
@@ -124,16 +135,17 @@ if [ "$#" -eq 1 ]; then
 fi
 
 echo "Installing with $cores cores"
-build_mpi_scheduler $cores
+build_mpi_scheduler "$cores"
 if [[ "$OSTYPE" == "darwin"* ]]; then
   echo "MacOS install, not installing raxml and modeltest as libraries"
 else
-  build_raxml_lib $cores
-  build_modeltest_lib $cores
+  build_raxml_lib "$cores"
+  build_modeltest_lib "$cores"
 fi
-build_raxml_exec $cores
-build_modeltest_exec $cores
+build_raxml_exec "$cores"
+build_modeltest_exec "$cores"
 build_astral
+build_aster "$cores"
 finish_install
 
 echo "Running unit tests..."

--- a/install.sh
+++ b/install.sh
@@ -122,7 +122,9 @@ finish_install() {
   fi
   install "ASTRAL/Astral/astral.jar"
   install "ASTRAL/Astral/lib"
-  install "ASTER/bin"
+  install "ASTER/bin/astral"
+  install "ASTER/bin/astral-pro"
+  install "ASTER/bin/astral-hybrid"
   echo ""
 }
 

--- a/install.sh
+++ b/install.sh
@@ -122,7 +122,7 @@ finish_install() {
   fi
   install "ASTRAL/Astral/astral.jar"
   install "ASTRAL/Astral/lib"
-  install "ASTER/bin/bin"
+  install "ASTER/bin"
   echo ""
 }
 

--- a/install_scheduler_only.sh
+++ b/install_scheduler_only.sh
@@ -13,12 +13,12 @@ build_mpi_scheduler() {
   echo "*********************************"
   echo "** Installing mpi_scheduler... **"
   echo "*********************************"
-  cd MPIScheduler || exit 1
+  cd MPIScheduler || exit
   mkdir -p build
   cd build || exit 1
   cmake .. || exit 1
   make -j "$1" || exit 1
-  cd ../.. || exit 1
+  cd ../.. || exit
 }
 
 build_raxml_lib() {
@@ -65,7 +65,11 @@ build_modeltest_exec() {
   cd modeltest || exit 1
   mkdir -p build
   cd build || exit 1
-  cmake -DUSE_MPI=OFF -DBUILD_AS_LIBRARY=OFF -DUSE_LIBPLL_CMAKE=ON .. || exit 1
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    cmake -DUSE_MPI=OFF .. || exit 1
+  else
+    cmake -DUSE_MPI=OFF -DBUILD_AS_LIBRARY=OFF -DUSE_LIBPLL_CMAKE=ON .. || exit 1
+  fi
   make -j "$1" || exit 1
   cd ../../ || exit 1
 }
@@ -77,9 +81,17 @@ build_astral() {
   cd ASTRAL || exit 1
   unzip -o ./*.zip
   cd Astral || exit 1
-  #mv astral.5.6.3.jar astral.jar
   mv astral.*.jar astral.jar
   cd ../../ || exit 1
+}
+
+build_aster() {
+  echo "******************************************"
+  echo "** Installing ASTER...                 **"
+  echo "******************************************"
+  cd ASTER || exit 1
+  make -j "$1" || exit 1
+  cd .. || exit 1
 }
 
 print_no_recursive_warning() {
@@ -102,14 +114,17 @@ finish_install() {
   install "MPIScheduler/build/mpi-scheduler"
   install "raxml-ng/bin/raxml-ng"
   install "modeltest/bin/modeltest-ng"
-  #if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  if [ "$(uname -s)" == "Linux" ]; then
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo "MacOS install, skipping dynamic libraries installation"
+  else
     install "raxml-ng/bin/raxml-ng-mpi.so"
     install "modeltest/build/src/modeltest-ng-mpi.so"
   fi
   install "ASTRAL/Astral/astral.jar"
   install "ASTRAL/Astral/lib"
-  install "ASTER/bin"
+  install "ASTER/bin/astral"
+  install "ASTER/bin/astral-pro"
+  install "ASTER/bin/astral-hybrid"
   echo ""
 }
 

--- a/install_scheduler_only.sh
+++ b/install_scheduler_only.sh
@@ -1,83 +1,85 @@
 #!/bin/bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 bindir="$DIR/pargenes/pargenes_binaries"
 echo "Running from $DIR"
 
 install() {
   echo "cp -r $1 $bindir"
-  cp -r $1 $bindir
+  cp -r $1 "$bindir"
 }
 
 build_mpi_scheduler() {
   echo "*********************************"
   echo "** Installing mpi_scheduler... **"
   echo "*********************************"
-  cd MPIScheduler
+  cd MPIScheduler || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake .. || exit 1
-  make -j $1 || exit 1
-  cd ../..
+  make -j "$1" || exit 1
+  cd ../.. || exit 1
 }
 
 build_raxml_lib() {
   echo "************************************"
   echo "** Installing raxml-ng library ...**"
   echo "************************************"
-  cd raxml-ng
+  cd raxml-ng || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake -DUSE_TERRAPHAST=OFF -DUSE_MPI=ON -DBUILD_AS_LIBRARY=ON .. || exit 1
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_raxml_exec() {
   echo "***************************************"
   echo "** Installing raxml-ng executable ...**"
   echo "***************************************"
-  cd raxml-ng
+  cd raxml-ng || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake -DUSE_TERRAPHAST=OFF -DUSE_MPI=OFF -DBUILD_AS_LIBRARY=OFF .. || exit 1
   cmake .. || exit 1
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_modeltest_lib() {
   echo "******************************************"
   echo "** Installing model-test-ng library ... **"
   echo "******************************************"
-  cd modeltest
+  cd modeltest || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake -DUSE_MPI=ON -DBUILD_AS_LIBRARY=ON .. || exit 1
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_modeltest_exec() {
   echo "******************************************"
   echo "** Installing model-test-ng executable ... **"
   echo "******************************************"
-  cd modeltest
+  cd modeltest || exit 1
   mkdir -p build
-  cd build
+  cd build || exit 1
   cmake -DUSE_MPI=OFF -DBUILD_AS_LIBRARY=OFF -DUSE_LIBPLL_CMAKE=ON .. || exit 1
-  make -j $1 || exit 1
-  cd ../../
+  make -j "$1" || exit 1
+  cd ../../ || exit 1
 }
 
 build_astral() {
   echo "******************************************"
   echo "** Installing ASTRAL...                 **"
   echo "******************************************"
-  cd ASTRAL
-  unzip -o *.zip
-  cd Astral
-  mv astral.5.6.3.jar astral.jar
-  cd ../../
+  cd ASTRAL || exit 1
+  unzip -o ./*.zip
+  cd Astral || exit 1
+  #mv astral.5.6.3.jar astral.jar
+  mv astral.*.jar astral.jar
+  cd ../../ || exit 1
 }
 
 print_no_recursive_warning() {
@@ -96,16 +98,18 @@ check_recursive() {
 finish_install() {
   echo ""
   echo "Copying all binaries into $bindir"
-  mkdir -p $bindir
+  mkdir -p "$bindir"
   install "MPIScheduler/build/mpi-scheduler"
   install "raxml-ng/bin/raxml-ng"
-  install "modeltest/bin/modeltest-ng" 
-  if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  install "modeltest/bin/modeltest-ng"
+  #if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  if [ "$(uname -s)" == "Linux" ]; then
     install "raxml-ng/bin/raxml-ng-mpi.so"
     install "modeltest/build/src/modeltest-ng-mpi.so"
   fi
   install "ASTRAL/Astral/astral.jar"
   install "ASTRAL/Astral/lib"
+  install "ASTER/bin"
   echo ""
 }
 
@@ -118,7 +122,6 @@ if [ "$#" -eq 1 ]; then
 fi
 
 echo "Installing with $cores cores"
-build_mpi_scheduler $cores
+build_mpi_scheduler "$cores"
 finish_install
-
 

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -24,25 +24,25 @@ def check_argument_dir(f, name):
 def parse_arguments(args):
   parser = argparse.ArgumentParser(args)
   # general arguments
-  parser.add_argument('-V', '--version', 
-      action='version', 
-      version="ParGenes ("+version.get_pargenes_version_string()+")")   
+  parser.add_argument('-V', '--version',
+      action='version',
+      version="ParGenes ("+version.get_pargenes_version_string()+")")
   parser.add_argument("--dry-run",
       dest="dry_run",
       action="store_true",
       default=False,
       help="")
-  parser.add_argument('-a', "--alignments-dir", 
-      dest="alignments_dir", 
+  parser.add_argument('-a', "--alignments-dir",
+      dest="alignments_dir",
       help="Directory containing the fasta files")
-  parser.add_argument('-o', "--output-dir", 
-      dest="output_dir", 
+  parser.add_argument('-o', "--output-dir",
+      dest="output_dir",
       help="Output directory")
-  parser.add_argument("-c", "--cores", 
+  parser.add_argument("-c", "--cores",
       dest="cores",
       type=int,
       help="The number of computational cores available for computation. Should at least 2.")
-  parser.add_argument("--seed", 
+  parser.add_argument("--seed",
       dest="seed",
       type=int,
       help="Random seed, for reproductibility of RAxML-NG runs. Set to 0 by default",
@@ -53,7 +53,7 @@ def parse_arguments(args):
       default=False,
       help="Allow pargenes to continue the analysis from the last checkpoint")
   parser.add_argument("--msa-filter",
-      dest="msa_filter", 
+      dest="msa_filter",
       help="A file containing the names of the msa files to process")
   parser.add_argument("-d", "--datatype",
       dest="datatype",
@@ -86,27 +86,27 @@ def parse_arguments(args):
       default=False,
       help="Stop ParGenes when a job fails")
   # raxml arguments
-  parser.add_argument("--per-msa-raxml-parameters", 
-      dest="per_msa_raxml_parameters", 
+  parser.add_argument("--per-msa-raxml-parameters",
+      dest="per_msa_raxml_parameters",
       help="A file containing per-msa raxml parameters")
-  parser.add_argument("-s", "--random-starting-trees", 
-      dest="random_starting_trees", 
+  parser.add_argument("-s", "--random-starting-trees",
+      dest="random_starting_trees",
       type=int,
       default=1,
       help="The number of starting trees")
-  parser.add_argument("-p", "--parsimony-starting-trees", 
-      dest="parsimony_starting_trees", 
+  parser.add_argument("-p", "--parsimony-starting-trees",
+      dest="parsimony_starting_trees",
       type=int,
       default=0,
       help="The number of starting parsimony trees")
-  parser.add_argument("-r", "--raxml-global-parameters", 
+  parser.add_argument("-r", "--raxml-global-parameters",
       dest="raxml_global_parameters", 
       help="A file containing the parameters to pass to raxml")
-  parser.add_argument("-R", "--raxml-global-parameters-string", 
-      dest="raxml_global_parameters_string", 
+  parser.add_argument("-R", "--raxml-global-parameters-string",
+      dest="raxml_global_parameters_string",
       help="List of parameters to pass to raxml (see also --raxml-global-parameters)")
-  parser.add_argument("-b", "--bs-trees", 
-      dest="bootstraps", 
+  parser.add_argument("-b", "--bs-trees",
+      dest="bootstraps",
       type=int,
       default=0,
       help="The number of bootstrap trees to compute")
@@ -115,7 +115,7 @@ def parse_arguments(args):
       action="store_true",
       default=False,
       help="Stop computing bootstrap trees after autoMRE bootstrap convergence test. You have to specify the maximum number of bootstrap trees with -b or --bs-tree")
-  parser.add_argument("--raxml-binary", 
+  parser.add_argument("--raxml-binary",
       dest="raxml_binary",
       default="",
       help="Custom path to raxml-ng executable. Please refer to the wiki before setting this variable yourself.")
@@ -130,11 +130,11 @@ def parse_arguments(args):
       action="store_true",
       default=False,
       help="Autodetect the model with modeltest")
-  parser.add_argument("--modeltest-global-parameters", 
-      dest="modeltest_global_parameters", 
+  parser.add_argument("--modeltest-global-parameters",
+      dest="modeltest_global_parameters",
       help="A file containing the parameters to pass to modeltest")
   parser.add_argument("--per-msa-modeltest-parameters",
-      dest="per_msa_modeltest_parameters", 
+      dest="per_msa_modeltest_parameters",
       help="A file containing per-msa modeltest parameters")
   parser.add_argument("--modeltest-criteria",
       dest="modeltest_criteria",
@@ -146,7 +146,7 @@ def parse_arguments(args):
       type=int,
       default=16,
       help="Number of cores to assign to each modeltest core (at least 4)")
-  parser.add_argument("--modeltest-binary", 
+  parser.add_argument("--modeltest-binary",
       dest="modeltest_binary",
       default="",
       help="Custom path to modeltest-ng executable. Please refer to the wiki before setting this variable yourself.")
@@ -156,13 +156,26 @@ def parse_arguments(args):
       action="store_true",
       default=False,
       help="Infer a species tree with astral")
-  parser.add_argument("--astral-global-parameters", 
+  parser.add_argument("--astral-global-parameters",
       dest="astral_global_parameters", 
       help="A file containing additional parameters to pass to astral")
-  parser.add_argument("--astral-jar", 
+  parser.add_argument("--astral-jar",
       dest="astral_jar",
       default="",
       help="Custom path to ASTRAL jar file.")
+  # aster arguments
+  parser.add_argument("--use-aster",
+      dest="use_aster",
+      action="store_true",
+      default=False,
+      help="Infer a species tree with aster")
+  parser.add_argument("--aster-global-parameters",
+      dest="aster_global_parameters",
+      help="A file containing additional parameters to pass to aster")
+  parser.add_argument("--aster-bin",
+      dest="aster_bin",
+      default="astral",
+      help="Name or custom path to aster binary file (astral|astral-hybrid|astral-pro|caster-pair|caster-site|caster-site_branchlength)")
   # experiments
   parser.add_argument("--experiment-disable-jobs-sorting",
       dest="disable_job_sorting",

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -25,11 +25,11 @@ def check_argument_aster_bin(f, name):
   if '/' in f:
     check_argument_file(f, name)
   else:
-    scriptdir = os.path.dirname(os.path.realpath(__file__))
-    binaries_dir = os.path.join(scriptdir, "..", "pargenes_binaries")
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    binaries_dir = os.path.join(script_dir, "..", "pargenes_binaries")
     aster_bins = [fn for fn in glob.glob('astral*', root_dir=binaries_dir) if not fn.endswith('.jar')]
-    if f not in aster_files:
-      exit_msg("Error: invalid name '" + f + "'. Valid options are " + '|'.join(aster_files) +  "\n")
+    if f not in aster_bins:
+      exit_msg("Error: invalid name '" + f + "'. Valid options are " + '|'.join(aster_bins) +  "\n")
 
 # parse the command line and return the arguments
 def parse_arguments(args):
@@ -197,6 +197,7 @@ def parse_arguments(args):
     default=0,
     help="Number of time the scheduler should try to restart after an error")
   op = parser.parse_args()
+  # after parse
   print("after parse:")
   check_argument_dir(op.alignments_dir, "alignment")
   check_argument_file(op.msa_filter, "msa filter")
@@ -206,8 +207,10 @@ def parse_arguments(args):
   check_argument_file(op.modeltest_global_parameters, "modeltest_global_parameters")
   check_argument_file(op.astral_global_parameters, "astral_global_parameters")
   check_argument_file(op.aster_global_parameters, "aster_global_parameters")
-  check_argument_file(op.astral_jar, "astral_jar")
-  check_argument_aster_bin(op.aster_bin, "aster_bin")
+  if (op.astral_jar):
+    check_astral_jar_argument(op.astral_jar, "astral_jar")
+  if op.aster_bin:
+    check_aster_bin_argument(op.aster_bin, "aster_bin")
   check_mandatory_field(op.alignments_dir, "alignment directory (\"-a\"")
   check_mandatory_field(op.output_dir, "output directory (\"-o\")")
   if (op.autoMRE and op.bootstraps < 1):

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -35,7 +35,9 @@ def check_argument_aster_bin(f, name):
   else:
     script_dir = os.path.dirname(os.path.realpath(__file__))
     binaries_dir = os.path.join(script_dir, "..", "pargenes_binaries")
-    aster_bins = [fn for fn in glob.glob('astral*', root_dir=binaries_dir) if not fn.endswith('.jar')]
+    #aster_bins = [fn for fn in glob.glob('astral*', root_dir=binaries_dir) if not fn.endswith('.jar')] # root_dir does not work on both 3.8 and 3.10
+    search_pattern = binaries_dir + '/' + 'astral*'
+    aster_bins = [os.path.basename(fn) for fn in glob.glob(search_pattern) if not fn.endswith('.jar')]
     if f not in aster_bins:
       exit_msg("Error: invalid name '" + f + "'. Valid options are " + '|'.join(aster_bins) +  "\n")
 

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -3,6 +3,7 @@ import sys
 import os
 import logger
 import version
+import glob
 
 def exit_msg(msg):
   logger.error(msg)
@@ -19,6 +20,16 @@ def check_argument_file(f, name):
 def check_argument_dir(f, name):
   if (None != f and not os.path.isdir(f)):
     exit_msg("Error: invalid " + name + " directory: " + f)
+
+def check_argument_aster_bin(f, name):
+  if '/' in f:
+    check_argument_file(f, name)
+  else:
+    scriptdir = os.path.dirname(os.path.realpath(__file__))
+    binaries_dir = os.path.join(scriptdir, "..", "pargenes_binaries")
+    aster_bins = [fn for fn in glob.glob('astral*', root_dir=binaries_dir) if not fn.endswith('.jar')]
+    if f not in aster_files:
+      exit_msg("Error: invalid name '" + f + "'. Valid options are " + '|'.join(aster_files) +  "\n")
 
 # parse the command line and return the arguments
 def parse_arguments(args):
@@ -196,7 +207,7 @@ def parse_arguments(args):
   check_argument_file(op.astral_global_parameters, "astral_global_parameters")
   check_argument_file(op.aster_global_parameters, "aster_global_parameters")
   check_argument_file(op.astral_jar, "astral_jar")
-  check_argument_file(op.aster_bin, "aster_bin")
+  check_argument_aster_bin(op.aster_bin, "aster_bin")
   check_mandatory_field(op.alignments_dir, "alignment directory (\"-a\"")
   check_mandatory_field(op.output_dir, "output directory (\"-o\")")
   if (op.autoMRE and op.bootstraps < 1):

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -21,6 +21,14 @@ def check_argument_dir(f, name):
   if (None != f and not os.path.isdir(f)):
     exit_msg("Error: invalid " + name + " directory: " + f)
 
+def check_argument_astral_jar(f, name):
+  if '/' in f:
+    check_argument_file(f, name)
+    jar_lib = os.path.dirname(f) + '/' + 'lib'
+    check_argument_dir(jar_lib, "astral.jar lib folder")
+  else:
+    exit_msg("Error: invalid path to " + name + " directory: " + f)
+
 def check_argument_aster_bin(f, name):
   if '/' in f:
     check_argument_file(f, name)
@@ -208,9 +216,9 @@ def parse_arguments(args):
   check_argument_file(op.astral_global_parameters, "astral_global_parameters")
   check_argument_file(op.aster_global_parameters, "aster_global_parameters")
   if (op.astral_jar):
-    check_astral_jar_argument(op.astral_jar, "astral_jar")
+    check_argument_astral_jar(op.astral_jar, "astral_jar")
   if op.aster_bin:
-    check_aster_bin_argument(op.aster_bin, "aster_bin")
+    check_argument_aster_bin(op.aster_bin, "aster_bin")
   check_mandatory_field(op.alignments_dir, "alignment directory (\"-a\"")
   check_mandatory_field(op.output_dir, "output directory (\"-o\")")
   if (op.autoMRE and op.bootstraps < 1):

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -100,7 +100,7 @@ def parse_arguments(args):
     default=0,
     help="The number of starting parsimony trees")
   parser.add_argument("-r", "--raxml-global-parameters",
-    dest="raxml_global_parameters", 
+    dest="raxml_global_parameters",
     help="A file containing the parameters to pass to raxml")
   parser.add_argument("-R", "--raxml-global-parameters-string",
     dest="raxml_global_parameters_string",
@@ -157,7 +157,7 @@ def parse_arguments(args):
     default=False,
     help="Infer a species tree with astral")
   parser.add_argument("--astral-global-parameters",
-    dest="astral_global_parameters", 
+    dest="astral_global_parameters",
     help="A file containing additional parameters to pass to astral")
   parser.add_argument("--astral-jar",
     dest="astral_jar",
@@ -168,7 +168,7 @@ def parse_arguments(args):
     dest="use_aster",
     action="store_true",
     default=False,
-    help="Infer a species tree with aster")
+    help="Infer a species tree with aster. Default is to use (aster) astral, but this can be changed with option --aster-bin")
   parser.add_argument("--aster-global-parameters",
     dest="aster_global_parameters",
     help="A file containing additional parameters to pass to aster")

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -161,7 +161,6 @@ def parse_arguments(args):
     help="A file containing additional parameters to pass to astral")
   parser.add_argument("--astral-jar",
     dest="astral_jar",
-    default="",
     help="Custom path to ASTRAL jar file.")
   # aster arguments
   parser.add_argument("--use-aster",
@@ -174,7 +173,6 @@ def parse_arguments(args):
     help="A file containing additional parameters to pass to aster")
   parser.add_argument("--aster-bin",
     dest="aster_bin",
-    default="",
     help="Name or custom path to aster binary file (astral|astral-hybrid|astral-pro)")
   # experiments
   parser.add_argument("--experiment-disable-jobs-sorting",
@@ -197,6 +195,8 @@ def parse_arguments(args):
   check_argument_file(op.modeltest_global_parameters, "modeltest_global_parameters")
   check_argument_file(op.astral_global_parameters, "astral_global_parameters")
   check_argument_file(op.aster_global_parameters, "aster_global_parameters")
+  check_argument_file(op.astral_jar, "astral_jar")
+  check_argument_file(op.aster_bin, "aster_bin")
   check_mandatory_field(op.alignments_dir, "alignment directory (\"-a\"")
   check_mandatory_field(op.output_dir, "output directory (\"-o\")")
   if (op.autoMRE and op.bootstraps < 1):

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -175,20 +175,7 @@ def parse_arguments(args):
   parser.add_argument("--aster-bin",
     dest="aster_bin",
     default="astral",
-    help="Name or custom path to aster binary file (astral|astral-hybrid|astral-pro|caster-pair|caster-site|caster-site_branchlength)")
-  # caster arguments
-  parser.add_argument("--use-caster",
-    dest="use_caster",
-    action="store_true",
-    default=False,
-    help="Infer a species tree with caster")
-  parser.add_argument("--caster-global-parameters",
-    dest="caster_global_parameters",
-    help="A file containing additional parameters to pass to caster")
-  parser.add_argument("--caster-bin",
-    dest="caster_bin",
-    default="caster-site",
-    help="Name or custom path to caster binary file (caster-pair|caster-site|caster-site_branchlength)")
+    help="Name or custom path to aster binary file (astral|astral-hybrid|astral-pro)")
   # experiments
   parser.add_argument("--experiment-disable-jobs-sorting",
     dest="disable_job_sorting",

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -174,7 +174,7 @@ def parse_arguments(args):
     help="A file containing additional parameters to pass to aster")
   parser.add_argument("--aster-bin",
     dest="aster_bin",
-    default="astral",
+    default="",
     help="Name or custom path to aster binary file (astral|astral-hybrid|astral-pro)")
   # experiments
   parser.add_argument("--experiment-disable-jobs-sorting",
@@ -195,6 +195,8 @@ def parse_arguments(args):
   check_argument_file(op.raxml_global_parameters, "raxml_global_parameters")
   check_argument_file(op.per_msa_modeltest_parameters, "per_msa_modeltest_parameters")
   check_argument_file(op.modeltest_global_parameters, "modeltest_global_parameters")
+  check_argument_file(op.astral_global_parameters, "astral_global_parameters")
+  check_argument_file(op.aster_global_parameters, "aster_global_parameters")
   check_mandatory_field(op.alignments_dir, "alignment directory (\"-a\"")
   check_mandatory_field(op.output_dir, "output directory (\"-o\")")
   if (op.autoMRE and op.bootstraps < 1):

--- a/pargenes/pargenes_src/arguments.py
+++ b/pargenes/pargenes_src/arguments.py
@@ -25,163 +25,176 @@ def parse_arguments(args):
   parser = argparse.ArgumentParser(args)
   # general arguments
   parser.add_argument('-V', '--version',
-      action='version',
-      version="ParGenes ("+version.get_pargenes_version_string()+")")
+    action='version',
+    version="ParGenes ("+version.get_pargenes_version_string()+")")
   parser.add_argument("--dry-run",
-      dest="dry_run",
-      action="store_true",
-      default=False,
-      help="")
+    dest="dry_run",
+    action="store_true",
+    default=False,
+    help="")
   parser.add_argument('-a', "--alignments-dir",
-      dest="alignments_dir",
-      help="Directory containing the fasta files")
+    dest="alignments_dir",
+    help="Directory containing the fasta files")
   parser.add_argument('-o', "--output-dir",
-      dest="output_dir",
-      help="Output directory")
+    dest="output_dir",
+    help="Output directory")
   parser.add_argument("-c", "--cores",
-      dest="cores",
-      type=int,
-      help="The number of computational cores available for computation. Should at least 2.")
+    dest="cores",
+    type=int,
+    help="The number of computational cores available for computation. Should at least 2.")
   parser.add_argument("--seed",
-      dest="seed",
-      type=int,
-      help="Random seed, for reproductibility of RAxML-NG runs. Set to 0 by default",
-      default=0)
+    dest="seed",
+    type=int,
+    help="Random seed, for reproductibility of RAxML-NG runs. Set to 0 by default",
+    default=0)
   parser.add_argument("--continue",
-      dest="do_continue",
-      action="store_true",
-      default=False,
-      help="Allow pargenes to continue the analysis from the last checkpoint")
+    dest="do_continue",
+    action="store_true",
+    default=False,
+    help="Allow pargenes to continue the analysis from the last checkpoint")
   parser.add_argument("--msa-filter",
-      dest="msa_filter",
-      help="A file containing the names of the msa files to process")
+    dest="msa_filter",
+    help="A file containing the names of the msa files to process")
   parser.add_argument("-d", "--datatype",
-      dest="datatype",
-      choices=["nt", "aa"],
-      default="nt",
-      help="Alignments datatype")
+    dest="datatype",
+    choices=["nt", "aa"],
+    default="nt",
+    help="Alignments datatype")
   parser.add_argument("--scheduler",
-      dest="scheduler",
-      choices=["split", "onecore", "fork"],
-      default="split",
-      help="Expert-user only.")
+    dest="scheduler",
+    choices=["split", "onecore", "fork"],
+    default="split",
+    help="Expert-user only.")
   parser.add_argument("--core-assignment",
-      dest="core_assignment",
-      choices=["high", "medium", "low"],
-      default="medium",
-      help="Policy to decide the per-job number of cores (low favors a low per-job number of cores)")
+    dest="core_assignment",
+    choices=["high", "medium", "low"],
+    default="medium",
+    help="Policy to decide the per-job number of cores (low favors a low per-job number of cores)")
   parser.add_argument("--valgrind",
-      dest="valgrind",
-      action="store_true",
-      default=False,
-      help="Run the scheduler with valgrind")
+    dest="valgrind",
+    action="store_true",
+    default=False,
+    help="Run the scheduler with valgrind")
   parser.add_argument("--constrain-search",
-      dest="constrain_search",
-      action="store_true",
-      default=False,
-      help="Constrain the raxml searches")
+    dest="constrain_search",
+    action="store_true",
+    default=False,
+    help="Constrain the raxml searches")
   parser.add_argument("--job-failure-fatal",
-      dest="job_failure_fatal",
-      action="store_true",
-      default=False,
-      help="Stop ParGenes when a job fails")
+    dest="job_failure_fatal",
+    action="store_true",
+    default=False,
+    help="Stop ParGenes when a job fails")
   # raxml arguments
   parser.add_argument("--per-msa-raxml-parameters",
-      dest="per_msa_raxml_parameters",
-      help="A file containing per-msa raxml parameters")
+    dest="per_msa_raxml_parameters",
+    help="A file containing per-msa raxml parameters")
   parser.add_argument("-s", "--random-starting-trees",
-      dest="random_starting_trees",
-      type=int,
-      default=1,
-      help="The number of starting trees")
+    dest="random_starting_trees",
+    type=int,
+    default=1,
+    help="The number of starting trees")
   parser.add_argument("-p", "--parsimony-starting-trees",
-      dest="parsimony_starting_trees",
-      type=int,
-      default=0,
-      help="The number of starting parsimony trees")
+    dest="parsimony_starting_trees",
+    type=int,
+    default=0,
+    help="The number of starting parsimony trees")
   parser.add_argument("-r", "--raxml-global-parameters",
-      dest="raxml_global_parameters", 
-      help="A file containing the parameters to pass to raxml")
+    dest="raxml_global_parameters", 
+    help="A file containing the parameters to pass to raxml")
   parser.add_argument("-R", "--raxml-global-parameters-string",
-      dest="raxml_global_parameters_string",
-      help="List of parameters to pass to raxml (see also --raxml-global-parameters)")
+    dest="raxml_global_parameters_string",
+    help="List of parameters to pass to raxml (see also --raxml-global-parameters)")
   parser.add_argument("-b", "--bs-trees",
-      dest="bootstraps",
-      type=int,
-      default=0,
-      help="The number of bootstrap trees to compute")
+    dest="bootstraps",
+    type=int,
+    default=0,
+    help="The number of bootstrap trees to compute")
   parser.add_argument("--autoMRE",
-      dest="autoMRE",
-      action="store_true",
-      default=False,
-      help="Stop computing bootstrap trees after autoMRE bootstrap convergence test. You have to specify the maximum number of bootstrap trees with -b or --bs-tree")
+    dest="autoMRE",
+    action="store_true",
+    default=False,
+    help="Stop computing bootstrap trees after autoMRE bootstrap convergence test. You have to specify the maximum number of bootstrap trees with -b or --bs-tree")
   parser.add_argument("--raxml-binary",
-      dest="raxml_binary",
-      default="",
-      help="Custom path to raxml-ng executable. Please refer to the wiki before setting this variable yourself.")
+    dest="raxml_binary",
+    default="",
+    help="Custom path to raxml-ng executable. Please refer to the wiki before setting this variable yourself.")
   parser.add_argument("--percentage-jobs-double-cores",
-      dest="percentage_jobs_double_cores",
-      type=float,
-      default=0.05,
-      help="Percentage (between 0 and 1) of jobs that will receive twice more cores")
+    dest="percentage_jobs_double_cores",
+    type=float,
+    default=0.05,
+    help="Percentage (between 0 and 1) of jobs that will receive twice more cores")
   # modeltest arguments
   parser.add_argument("-m", "--use-modeltest",
-      dest="use_modeltest",
-      action="store_true",
-      default=False,
-      help="Autodetect the model with modeltest")
+    dest="use_modeltest",
+    action="store_true",
+    default=False,
+    help="Autodetect the model with modeltest")
   parser.add_argument("--modeltest-global-parameters",
-      dest="modeltest_global_parameters",
-      help="A file containing the parameters to pass to modeltest")
+    dest="modeltest_global_parameters",
+    help="A file containing the parameters to pass to modeltest")
   parser.add_argument("--per-msa-modeltest-parameters",
-      dest="per_msa_modeltest_parameters",
-      help="A file containing per-msa modeltest parameters")
+    dest="per_msa_modeltest_parameters",
+    help="A file containing per-msa modeltest parameters")
   parser.add_argument("--modeltest-criteria",
-      dest="modeltest_criteria",
-      choices=["AICc", "AIC", "BIC"],
-      default="AICc",
-      help="Alignments datatype")
+    dest="modeltest_criteria",
+    choices=["AICc", "AIC", "BIC"],
+    default="AICc",
+    help="Alignments datatype")
   parser.add_argument("--modeltest-perjob-cores",
-      dest="modeltest_cores",
-      type=int,
-      default=16,
-      help="Number of cores to assign to each modeltest core (at least 4)")
+    dest="modeltest_cores",
+    type=int,
+    default=16,
+    help="Number of cores to assign to each modeltest core (at least 4)")
   parser.add_argument("--modeltest-binary",
-      dest="modeltest_binary",
-      default="",
-      help="Custom path to modeltest-ng executable. Please refer to the wiki before setting this variable yourself.")
+    dest="modeltest_binary",
+    default="",
+    help="Custom path to modeltest-ng executable. Please refer to the wiki before setting this variable yourself.")
   # astral arguments
   parser.add_argument("--use-astral",
-      dest="use_astral",
-      action="store_true",
-      default=False,
-      help="Infer a species tree with astral")
+    dest="use_astral",
+    action="store_true",
+    default=False,
+    help="Infer a species tree with astral")
   parser.add_argument("--astral-global-parameters",
-      dest="astral_global_parameters", 
-      help="A file containing additional parameters to pass to astral")
+    dest="astral_global_parameters", 
+    help="A file containing additional parameters to pass to astral")
   parser.add_argument("--astral-jar",
-      dest="astral_jar",
-      default="",
-      help="Custom path to ASTRAL jar file.")
+    dest="astral_jar",
+    default="",
+    help="Custom path to ASTRAL jar file.")
   # aster arguments
   parser.add_argument("--use-aster",
-      dest="use_aster",
-      action="store_true",
-      default=False,
-      help="Infer a species tree with aster")
+    dest="use_aster",
+    action="store_true",
+    default=False,
+    help="Infer a species tree with aster")
   parser.add_argument("--aster-global-parameters",
-      dest="aster_global_parameters",
-      help="A file containing additional parameters to pass to aster")
+    dest="aster_global_parameters",
+    help="A file containing additional parameters to pass to aster")
   parser.add_argument("--aster-bin",
-      dest="aster_bin",
-      default="astral",
-      help="Name or custom path to aster binary file (astral|astral-hybrid|astral-pro|caster-pair|caster-site|caster-site_branchlength)")
+    dest="aster_bin",
+    default="astral",
+    help="Name or custom path to aster binary file (astral|astral-hybrid|astral-pro|caster-pair|caster-site|caster-site_branchlength)")
+  # caster arguments
+  parser.add_argument("--use-caster",
+    dest="use_caster",
+    action="store_true",
+    default=False,
+    help="Infer a species tree with caster")
+  parser.add_argument("--caster-global-parameters",
+    dest="caster_global_parameters",
+    help="A file containing additional parameters to pass to caster")
+  parser.add_argument("--caster-bin",
+    dest="caster_bin",
+    default="caster-site",
+    help="Name or custom path to caster binary file (caster-pair|caster-site|caster-site_branchlength)")
   # experiments
   parser.add_argument("--experiment-disable-jobs-sorting",
-      dest="disable_job_sorting",
-      action="store_true",
-      default=False,
-      help="For experimenting only! Removes the sorting step in the scheduler")
+    dest="disable_job_sorting",
+    action="store_true",
+    default=False,
+    help="For experimenting only! Removes the sorting step in the scheduler")
   parser.add_argument("--retry",
     dest="retry",
     type=int,

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -74,8 +74,8 @@ def run_aster(pargenes_dir, aster_bin, parameters_file):
     pass
   gene_trees = get_gene_trees_file(pargenes_dir)
   extract_gene_trees(pargenes_dir, gene_trees)
-  library_path = os.path.abspath(os.path.join(aster_bin, os.pardir)) # TODO: check if needed
-  #aster_bin = os.path.basename(aster_bin)
+  #library_path = os.path.abspath(os.path.join(aster_bin, os.pardir)) # TODO: check if needed
+  #aster_bin = os.path.basename(aster_bin)# TODO: check if needed
   command = ""
   command += aster_bin + " "
   command += "-i " + gene_trees + " "

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -82,7 +82,6 @@ def run_aster(pargenes_dir, aster_bin, parameters_file):
   command += "-o " + aster_output + " "
   for arg in aster_args:
     command += arg + " "
-  sys.stderr.write(command)
   command = command[:-1]
   split_command = command.split(" ")
   out = open(aster_logs, "w")
@@ -110,7 +109,7 @@ if (__name__ == '__main__'):
   logger.init_logger(pargenes_dir)
   logger.timed_log(start, "Starting aster pargenes script...")
   scriptdir = os.path.dirname(os.path.realpath(__file__))
-  aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", "aster")
+  aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", "astral")
   run_aster(pargenes_dir, aster_bin, parameters_file)
   logger.timed_log(start, "End of aster pargenes script...")
 

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -75,7 +75,7 @@ def run_aster(pargenes_dir, aster_bin, parameters_file):
   gene_trees = get_gene_trees_file(pargenes_dir)
   extract_gene_trees(pargenes_dir, gene_trees)
   library_path = os.path.abspath(os.path.join(aster_bin, os.pardir)) # TODO: check if needed
-  aster_bin = os.path.basename(aster_bin)
+  #aster_bin = os.path.basename(aster_bin)
   command = ""
   command += aster_bin + " "
   command += "-i " + gene_trees + " "
@@ -110,7 +110,7 @@ if (__name__ == '__main__'):
   logger.init_logger(pargenes_dir)
   logger.timed_log(start, "Starting aster pargenes script...")
   scriptdir = os.path.dirname(os.path.realpath(__file__))
-  aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", aster_bin)
+  aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", "aster")
   run_aster(pargenes_dir, aster_bin, parameters_file)
   logger.timed_log(start, "End of aster pargenes script...")
 

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -21,7 +21,7 @@ def extract_gene_trees_support(pargenes_dir, gene_trees_filename):
         with open(os.path.join(results, f)) as reader:
           writer.write(treat_newick(reader.read()))
         count += 1
-  logger.info("ParGenes/Astral: " + str(count) + " gene trees (with support values) were found in ParGenes output directory")
+  logger.info("ParGenes/Aster: " + str(count) + " gene trees (with support values) were found in ParGenes output directory")
 
 def extract_gene_trees_ml(pargenes_dir, gene_trees_filename):
   results = os.path.join(pargenes_dir, "mlsearch_run", "results")
@@ -74,7 +74,7 @@ def run_aster(pargenes_dir, aster_bin, parameters_file):
     pass
   gene_trees = get_gene_trees_file(pargenes_dir)
   extract_gene_trees(pargenes_dir, gene_trees)
-  library_path = os.path.abspath(os.path.join(aster_bin, os.pardir))
+  #library_path = os.path.abspath(os.path.join(aster_bin, os.pardir))
   aster_bin = os.path.basename(aster_bin)
   command = ""
   command += aster_bin + " "
@@ -100,7 +100,7 @@ if (__name__ == '__main__'):
   if (len(sys.argv) != 2 and len(sys.argv) != 3):
     print("Error: syntax is:")
     print("<aster_bin> pargenes_dir [aster_parameters_file]")
-    print("aster_parameters_file is optional and should contain additional parameters to pass to aster call)")
+    print("aster_parameters_file is optional and should contain additional parameters to pass to aster call")
     exit(1)
   pargenes_dir = sys.argv[1]
   parameters_file = None

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -1,0 +1,146 @@
+import os
+import sys
+import subprocess
+import arguments
+import logger
+import time
+import report
+
+def treat_newick(newick):
+  return newick.replace("@", "at")
+
+def get_gene_trees_file(pargenes_dir):
+  return os.path.join(pargenes_dir, "aster_run", "gene_trees.newick")
+
+def extract_gene_trees_support(pargenes_dir, gene_trees_filename):
+  results = os.path.join(pargenes_dir, "supports_run", "results")
+  count = 0
+  with open(gene_trees_filename, "w") as writer:
+    for f in os.listdir(results):
+      if (f.endswith(".raxml.support") and not "tbe" in f):
+        with open(os.path.join(results, f)) as reader:
+          writer.write(treat_newick(reader.read()))
+        count += 1
+  logger.info("ParGenes/Astral: " + str(count) + " gene trees (with support values) were found in ParGenes output directory")
+
+def extract_gene_trees_ml(pargenes_dir, gene_trees_filename):
+  results = os.path.join(pargenes_dir, "mlsearch_run", "results")
+  count = 0
+  with open(gene_trees_filename, "w") as writer:
+    for msa in os.listdir(results):
+      tree_file = os.path.join(results, msa, msa + ".raxml.bestTree")
+      try:
+        with open(tree_file) as reader:
+          writer.write(treat_newick(reader.read()))
+        count += 1
+      except:
+        continue
+  logger.info("ParGenes/Aster: " + str(count) + " trees were found in ParGenes output directory")
+
+def extract_gene_trees(pargenes_dir, gene_trees_filename):
+  """ Get all ParGenes ML gene trees and store then in gene_trees_filename
+  """
+  with_supports = os.path.isdir(os.path.join(pargenes_dir, "supports_run"))
+  results = ""
+  if (with_supports):
+    extract_gene_trees_support(pargenes_dir, gene_trees_filename)
+  else:
+    extract_gene_trees_ml(pargenes_dir, gene_trees_filename)
+
+def get_additional_parameters(parameters_file):
+  if (parameters_file == None or parameters_file == ""):
+    return []
+  aster_options = open(parameters_file, "r").readlines()
+  if (len(aster_options) != 0):
+    return aster_options[0][:-1].split(" ")
+  else:
+    return []
+
+###################################
+#def get_alignments_list(pargenes_dir):
+#""" Collect a list of alignments as input to aster (caster*)
+#  - pargenes_dir     (str):        pargenes output directory
+#"""
+#
+#  return list_or_file
+###################################
+
+def run_aster(pargenes_dir, aster_bin, parameters_file):
+  """ Run aster on the ParGenes ML trees or Alignment files
+  - pargenes_dir     (str):        pargenes output directory
+  - aster_bin        (str):        name of binary
+  - parameters_file  (list(str)):  a file with the list of additional arguments to pass to astral
+  """
+  aster_args = get_additional_parameters(parameters_file)
+  aster_run_dir = os.path.join(pargenes_dir, "aster_run")
+  aster_output = os.path.join(astral_run_dir, "output_species_tree.newick")
+  aster_logs = os.path.join(astral_run_dir, "aster_logs.txt")
+  logger.info("Aster additional parameters:")
+  logger.info(aster_args)
+  try:
+    os.makedirs(aster_run_dir)
+  except:
+    pass
+  #gene_trees = get_gene_trees_file(pargenes_dir)
+  #extract_gene_trees(pargenes_dir, gene_trees)
+  ###########
+  #library_path = os.path.abspath(os.path.join(aster_bin, os.pardir))
+  #library_path = os.path.join(library_path, "lib")
+  ##astral_jar = os.path.basename(astral_jar)
+  #command = ""
+  #command += "java "
+  #command += "-D\"java.library.path=" + library_path + "\" "
+  #command +="-jar "
+  #command += astral_jar + " "
+  #command += "-i " + gene_trees + " "
+  #command += "-o " + astral_output + " "
+  ###########
+  #astral -t 4 -i gene_trees.newick -o astral.output_species_tree.newick
+  command = aster_bin + " "
+  # Need to check if we are using trees or alignments as input!
+  if aster_bin.startswith("astral"):
+    gene_trees = get_gene_trees_file(pargenes_dir)
+    extract_gene_trees(pargenes_dir, gene_trees)
+    command += "-i " + gene_trees + " "
+  elif aster_bin.startswith("caster"):
+    ##################### Need the list of alignments
+    #command += "-i " + alignment_list + " " #######
+  command += "-o " + aster_output + " "
+  ###########
+  for arg in aster_args:
+    command += arg + " "
+  sys.stderr.write(command)
+  command = command[:-1]
+  split_command = command.split(" ")
+  out = open(aster_logs, "w")
+  logger.info("Starting aster... Logs will be redirected to " + aster_logs)
+  p = subprocess.Popen(split_command, stdout=out, stderr=out)
+  p.wait()
+  if (0 != p.returncode):
+    logger.error("Aster execution failed")
+    report.report_and_exit(pargenes_dir, 1)
+
+def run_aster_pargenes(aster_bin, op):
+  run_aster(op.output_dir, aster_bin, op.aster_global_parameters)
+
+if (__name__ == '__main__'):
+  if (len(sys.argv) != 2 and len(sys.argv) != 3):
+    print("Error: syntax is:")
+    print("<aster_binary> pargenes_dir [aster_parameters_file]")
+    print("aster_parameters_file is optional and should contain additional parameters to pass to aster call)")
+    exit(1)
+  pargenes_dir = sys.argv[1]
+  parameters_file = None
+  if (len(sys.argv) > 2):
+    parameters_file = sys.argv[2]
+  start = time.time()
+  logger.init_logger(pargenes_dir)
+  logger.timed_log(start, "Starting aster pargenes script...")
+  scriptdir = os.path.dirname(os.path.realpath(__file__))
+  #########################
+  #aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", aster_xxxxxxxxxx)
+  #aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", "astral.jar")
+  #########################
+  run_aster(pargenes_dir, aster_bin, parameters_file)
+  logger.timed_log(start, "End of aster pargenes script...")
+

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -74,7 +74,7 @@ def run_aster(pargenes_dir, aster_bin, parameters_file):
     pass
   gene_trees = get_gene_trees_file(pargenes_dir)
   extract_gene_trees(pargenes_dir, gene_trees)
-  #library_path = os.path.abspath(os.path.join(aster_bin, os.pardir)) # TODO: check if needed
+  library_path = os.path.abspath(os.path.join(aster_bin, os.pardir)) # TODO: check if needed
   aster_bin = os.path.basename(aster_bin)
   command = ""
   command += aster_bin + " "

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -74,7 +74,7 @@ def run_aster(pargenes_dir, aster_bin, parameters_file):
     pass
   gene_trees = get_gene_trees_file(pargenes_dir)
   extract_gene_trees(pargenes_dir, gene_trees)
-  #library_path = os.path.abspath(os.path.join(aster_bin, os.pardir))
+  #library_path = os.path.abspath(os.path.join(aster_bin, os.pardir)) # TODO: check if needed
   aster_bin = os.path.basename(aster_bin)
   command = ""
   command += aster_bin + " "

--- a/pargenes/pargenes_src/aster.py
+++ b/pargenes/pargenes_src/aster.py
@@ -56,57 +56,30 @@ def get_additional_parameters(parameters_file):
   else:
     return []
 
-###################################
-#def get_alignments_list(pargenes_dir):
-#""" Collect a list of alignments as input to aster (caster*)
-#  - pargenes_dir     (str):        pargenes output directory
-#"""
-#
-#  return list_or_file
-###################################
-
 def run_aster(pargenes_dir, aster_bin, parameters_file):
-  """ Run aster on the ParGenes ML trees or Alignment files
+  """ Run aster on the ParGenes ML trees
   - pargenes_dir     (str):        pargenes output directory
-  - aster_bin        (str):        name of binary
-  - parameters_file  (list(str)):  a file with the list of additional arguments to pass to astral
+  - aster_bin        (str):        name of aster binary (<astral|astral-hybrid|astral-pro>)
+  - parameters_file  (list(str)):  a file with the list of additional arguments to pass to aster
   """
   aster_args = get_additional_parameters(parameters_file)
   aster_run_dir = os.path.join(pargenes_dir, "aster_run")
-  aster_output = os.path.join(astral_run_dir, "output_species_tree.newick")
-  aster_logs = os.path.join(astral_run_dir, "aster_logs.txt")
+  aster_output = os.path.join(aster_run_dir, "output_species_tree.newick")
+  aster_logs = os.path.join(aster_run_dir, "aster_logs.txt")
   logger.info("Aster additional parameters:")
   logger.info(aster_args)
   try:
     os.makedirs(aster_run_dir)
   except:
     pass
-  #gene_trees = get_gene_trees_file(pargenes_dir)
-  #extract_gene_trees(pargenes_dir, gene_trees)
-  ###########
-  #library_path = os.path.abspath(os.path.join(aster_bin, os.pardir))
-  #library_path = os.path.join(library_path, "lib")
-  ##astral_jar = os.path.basename(astral_jar)
-  #command = ""
-  #command += "java "
-  #command += "-D\"java.library.path=" + library_path + "\" "
-  #command +="-jar "
-  #command += astral_jar + " "
-  #command += "-i " + gene_trees + " "
-  #command += "-o " + astral_output + " "
-  ###########
-  #astral -t 4 -i gene_trees.newick -o astral.output_species_tree.newick
-  command = aster_bin + " "
-  # Need to check if we are using trees or alignments as input!
-  if aster_bin.startswith("astral"):
-    gene_trees = get_gene_trees_file(pargenes_dir)
-    extract_gene_trees(pargenes_dir, gene_trees)
-    command += "-i " + gene_trees + " "
-  elif aster_bin.startswith("caster"):
-    ##################### Need the list of alignments
-    #command += "-i " + alignment_list + " " #######
+  gene_trees = get_gene_trees_file(pargenes_dir)
+  extract_gene_trees(pargenes_dir, gene_trees)
+  library_path = os.path.abspath(os.path.join(aster_bin, os.pardir))
+  aster_bin = os.path.basename(aster_bin)
+  command = ""
+  command += aster_bin + " "
+  command += "-i " + gene_trees + " "
   command += "-o " + aster_output + " "
-  ###########
   for arg in aster_args:
     command += arg + " "
   sys.stderr.write(command)
@@ -126,7 +99,7 @@ def run_aster_pargenes(aster_bin, op):
 if (__name__ == '__main__'):
   if (len(sys.argv) != 2 and len(sys.argv) != 3):
     print("Error: syntax is:")
-    print("<aster_binary> pargenes_dir [aster_parameters_file]")
+    print("<aster_bin> pargenes_dir [aster_parameters_file]")
     print("aster_parameters_file is optional and should contain additional parameters to pass to aster call)")
     exit(1)
   pargenes_dir = sys.argv[1]
@@ -137,10 +110,7 @@ if (__name__ == '__main__'):
   logger.init_logger(pargenes_dir)
   logger.timed_log(start, "Starting aster pargenes script...")
   scriptdir = os.path.dirname(os.path.realpath(__file__))
-  #########################
-  #aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", aster_xxxxxxxxxx)
-  #aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", "astral.jar")
-  #########################
+  aster_bin = os.path.join(scriptdir, "..", "pargenes_binaries", aster_bin)
   run_aster(pargenes_dir, aster_bin, parameters_file)
   logger.timed_log(start, "End of aster pargenes script...")
 

--- a/pargenes/pargenes_src/astral.py
+++ b/pargenes/pargenes_src/astral.py
@@ -22,7 +22,7 @@ def extract_gene_trees_support(pargenes_dir, gene_trees_filename):
           writer.write(treat_newick(reader.read()))
         count += 1
   logger.info("ParGenes/Astral: " + str(count) + " gene trees (with support values) were found in ParGenes output directory")
-  
+
 def extract_gene_trees_ml(pargenes_dir, gene_trees_filename):
   results = os.path.join(pargenes_dir, "mlsearch_run", "results")
   count = 0
@@ -36,10 +36,9 @@ def extract_gene_trees_ml(pargenes_dir, gene_trees_filename):
       except:
         continue
   logger.info("ParGenes/Astral: " + str(count) + " trees were found in ParGenes output directory")
-  
-  
+
 def extract_gene_trees(pargenes_dir, gene_trees_filename):
-  """ Get all ParGenes ML gene trees and store then in gene_trees_filename 
+  """ Get all ParGenes ML gene trees and store then in gene_trees_filename
   """
   with_supports = os.path.isdir(os.path.join(pargenes_dir, "supports_run"))
   results = ""
@@ -55,9 +54,8 @@ def get_additional_parameters(parameters_file):
   if (len(astral_options) != 0):
     return astral_options[0][:-1].split(" ")
   else:
-    return [] 
-  
-  
+    return []
+
 def run_astral(pargenes_dir, astral_jar, parameters_file):
   """ Run astral on the ParGenes ML trees
   - pargenes_dir     (str):        pargenes output directory
@@ -85,7 +83,7 @@ def run_astral(pargenes_dir, astral_jar, parameters_file):
   command +="-jar "
   command += astral_jar + " "
   command += "-i " + gene_trees + " "
-  command += "-o " + astral_output + " " 
+  command += "-o " + astral_output + " "
   for arg in astral_args:
     command += arg + " "
   sys.stderr.write(command)
@@ -99,7 +97,6 @@ def run_astral(pargenes_dir, astral_jar, parameters_file):
     logger.error("Astral execution failed")
     report.report_and_exit(pargenes_dir, 1)
 
-
 def run_astral_pargenes(astral_jar, op):
   run_astral(op.output_dir, astral_jar, op.astral_global_parameters)
 
@@ -107,7 +104,7 @@ if (__name__ == '__main__'):
   if (len(sys.argv) != 2 and len(sys.argv) != 3):
     print("Error: syntax is:")
     print("python astral.py pargenes_dir [astral_parameters_file]")
-    print("astral_parameters_file is optional and should contain additional parameters to pass to astral call)")
+    print("astral_parameters_file is optional and should contain additional parameters to pass to astral call.")
     exit(1)
   pargenes_dir = sys.argv[1]
   parameters_file = None

--- a/pargenes/pargenes_src/astral.py
+++ b/pargenes/pargenes_src/astral.py
@@ -86,7 +86,6 @@ def run_astral(pargenes_dir, astral_jar, parameters_file):
   command += "-o " + astral_output + " "
   for arg in astral_args:
     command += arg + " "
-  sys.stderr.write(command)
   command = command[:-1]
   split_command = command.split(" ")
   out = open(astral_logs, "w")

--- a/pargenes/pargenes_src/pargenescore.py
+++ b/pargenes/pargenes_src/pargenescore.py
@@ -77,9 +77,6 @@ def main_raxml_runner(args, op):
         aster_bin = os.path.join(binaries_dir, op.aster_bin)
     else:
       aster_bin = os.path.join(binaries_dir, "astral")
-  if (op.aster_bin):
-    aster_bin = op.aster_bin
-  aster_bin = os.path.abspath(aster_bin)
   if (checkpoint_index < 1):
     msas = commons.init_msas(op)
     raxml.run_parsing_step(msas, raxml_library, op.scheduler, os.path.join(output_dir, "parse_run"), op.cores, op)

--- a/pargenes/pargenes_src/pargenescore.py
+++ b/pargenes/pargenes_src/pargenescore.py
@@ -60,15 +60,23 @@ def main_raxml_runner(args, op):
   else:
     raxml_library = os.path.join(binaries_dir, "raxml-ng-mpi.so")
     modeltest_library = os.path.join(binaries_dir, "modeltest-ng-mpi.so")
-  astral_jar = os.path.join(binaries_dir, "astral.jar")
-  aster_bin = os.path.join(binaries_dir, "astral")
   if (op.raxml_binary):
     raxml_library = op.raxml_binary
   if (op.modeltest_binary):
     modeltest_library = op.modeltest_binary
-  if (op.astral_jar):
-    astral_jar = op.astral_jar
-  astral_jar = os.path.abspath(astral_jar)
+  if (op.use_astral):
+    if (op.astral_jar):
+      astral_jar = os.path.abspath(op.astral_jar)
+    else:
+      astral_jar = os.path.join(binaries_dir, "astral.jar")
+  elif (op.use_aster):
+    if (op.aster_bin):
+      if '/' in op.aster_bin:
+        aster_bin = os.path.abspath(op.aster_bin)
+      else:
+        aster_bin = os.path.join(binaries_dir, op.aster_bin)
+    else:
+      aster_bin = os.path.join(binaries_dir, "astral")
   if (op.aster_bin):
     aster_bin = op.aster_bin
   aster_bin = os.path.abspath(aster_bin)

--- a/pargenes/pargenes_src/pargenescore.py
+++ b/pargenes/pargenes_src/pargenescore.py
@@ -12,6 +12,7 @@ import checkpoint
 import shutil
 import logger
 import astral
+import aster
 import report
 import datetime
 import version
@@ -27,9 +28,6 @@ def print_header(args):
   logger.info(" ".join(args))
   logger.info("")
 
-
-
-
 def print_stats(op):
   failed_commands = os.path.join(op.output_dir, "failed_commands.txt")
   if (os.path.isfile(failed_commands)):
@@ -37,7 +35,7 @@ def print_stats(op):
     logger.warning("Total number of jobs that failed: " + str(failed_number))
     logger.warning("For a detailed list, see " + failed_commands)
 
-def main_raxml_runner(args, op): 
+def main_raxml_runner(args, op):
   """ Run pargenes from the parsed arguments op """
   start = time.time()
   output_dir = op.output_dir
@@ -63,6 +61,7 @@ def main_raxml_runner(args, op):
     raxml_library = os.path.join(binaries_dir, "raxml-ng-mpi.so")
     modeltest_library = os.path.join(binaries_dir, "modeltest-ng-mpi.so")
   astral_jar = os.path.join(binaries_dir, "astral.jar")
+  aster_bin = os.path.join(binaries_dir, "astral")
   if (len(op.raxml_binary) > 1):
     raxml_library = op.raxml_binary
   if (len(op.modeltest_binary) > 1):
@@ -70,6 +69,10 @@ def main_raxml_runner(args, op):
   if (len(op.astral_jar) > 1):
     astral_jar = op.astral_jar
   astral_jar = os.path.abspath(astral_jar)
+  if (len(op.aster_bin) > 1):
+    aster_bin = op.aster_bin
+  # Test here if op.aster_bin is either aster,aster-pro,aster-hybrid (which all are in binaries_dir) or valid path?
+  aster_bin = os.path.abspath(aster_bin)
   if (checkpoint_index < 1):
     msas = commons.init_msas(op)
     raxml.run_parsing_step(msas, raxml_library, op.scheduler, os.path.join(output_dir, "parse_run"), op.cores, op)
@@ -81,7 +84,7 @@ def main_raxml_runner(args, op):
   if (op.dry_run):
     logger.info("End of the dry run. Exiting")
     return 0
-  logger.timed_log("end of anlysing parsing results") 
+  logger.timed_log("end of anlysing parsing results")
   if (op.use_modeltest):
     if (checkpoint_index < 2):
       modeltest.run(msas, output_dir, modeltest_library, modeltest_run_path, op)
@@ -92,16 +95,15 @@ def main_raxml_runner(args, op):
       shutil.move(os.path.join(output_dir, "parse_run"), os.path.join(output_dir, "old_parse_run"))
       raxml.run_parsing_step(msas, raxml_library, op.scheduler, os.path.join(output_dir, "parse_run"), op.cores, op)
       raxml.analyse_parsed_msas(msas, op)
-      logger.timed_log("end of the second parsing step") 
+      logger.timed_log("end of the second parsing step")
       checkpoint.write_checkpoint(output_dir, 2)
-  if (checkpoint_index < 3): 
+  if (checkpoint_index < 3):
     print("TODO UPDATE CHECKPOINT")
     if (op.constrain_search):
       print("Computing consensus trees ")
       samples = 100
       constraint.compute_constrain(msas, samples, raxml_library, op.scheduler, constrain_run_path, op.cores, op)
       logger.timed_log("end of consensus tree building")
-  
   if (checkpoint_index < 3):
     raxml.run(msas, op.random_starting_trees, op.parsimony_starting_trees, op.bootstraps, raxml_library, op.scheduler, raxml_run_path, op.cores, op)
     logger.timed_log("end of mlsearch mpi-scheduler run")
@@ -125,6 +127,10 @@ def main_raxml_runner(args, op):
     if (checkpoint_index < 7):
       astral.run_astral_pargenes(astral_jar,  op)
       checkpoint.write_checkpoint(output_dir, 7)
+  elif (op.use_aster):
+    if (checkpoint_index < 7):
+      aster.run_aster_pargenes(aster_bin,  op)
+      checkpoint.write_checkpoint(output_dir, 7)
   all_invalid = True
   for name, msa in msas.items():
     if (msa.valid):
@@ -141,20 +147,18 @@ def run_pargenes(args):
   try:
     op = arguments.parse_arguments(args)
   except Exception as inst:
-    logger.info("[Error] " + str(type(inst)) + " " + str(inst)) 
+    logger.info("[Error] " + str(type(inst)) + " " + str(inst))
     sys.exit(1)
   try:
     ret =  main_raxml_runner(args, op)
   except Exception as inst:
-    logger.info("[Error] " + str(type(inst)) + " " + str(inst)) 
+    logger.info("[Error] " + str(type(inst)) + " " + str(inst))
     report.report_and_exit(op.output_dir, 1)
   end = time.time()
   logger.timed_log("END OF THE RUN OF " + os.path.basename(__file__))
   if (ret != 0):
-    logger.info("Something went wrong, please check the logs") 
-
+    logger.info("Something went wrong, please check the logs")
 
 if __name__ == '__main__':
   run_pargenes(sys.argv)
-
 

--- a/pargenes/pargenes_src/pargenescore.py
+++ b/pargenes/pargenes_src/pargenescore.py
@@ -62,16 +62,15 @@ def main_raxml_runner(args, op):
     modeltest_library = os.path.join(binaries_dir, "modeltest-ng-mpi.so")
   astral_jar = os.path.join(binaries_dir, "astral.jar")
   aster_bin = os.path.join(binaries_dir, "astral")
-  if (len(op.raxml_binary) > 1):
+  if (op.raxml_binary):
     raxml_library = op.raxml_binary
-  if (len(op.modeltest_binary) > 1):
+  if (op.modeltest_binary):
     modeltest_library = op.modeltest_binary
-  if (len(op.astral_jar) > 1):
+  if (op.astral_jar):
     astral_jar = op.astral_jar
   astral_jar = os.path.abspath(astral_jar)
-  if (len(op.aster_bin) > 1):
+  if (op.aster_bin):
     aster_bin = op.aster_bin
-  # Test here if op.aster_bin is either aster,aster-pro,aster-hybrid (which all are in binaries_dir) or valid path?
   aster_bin = os.path.abspath(aster_bin)
   if (checkpoint_index < 1):
     msas = commons.init_msas(op)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -150,7 +150,7 @@ def test_ml_search(pargenes_script):
   command += "-c 4 "
   command += "-s 3 -p 3 "
   run_command(command, "ml_search_" + basename, output)
-  return check_all(output, True, False, True, False)
+  return check_all(output, True, False, True, False, False)
 
 def test_model_test(pargenes_script):
   basename = get_basename(pargenes_script)
@@ -166,7 +166,7 @@ def test_model_test(pargenes_script):
   command += " -m"
   command += " --modeltest-global-parameters " + example_modeltest_parameters
   run_command(command, "modeltest_" + basename, output)
-  return check_all(output, True, True, True, False)
+  return check_all(output, True, True, True, False, False)
 
 def test_bootstraps(pargenes_script):
   basename = get_basename(pargenes_script)
@@ -182,7 +182,7 @@ def test_bootstraps(pargenes_script):
   command += "-c 4 "
   command += " -b 3"
   run_command(command, "bootstraps" + basename, output)
-  return check_all(output, True, False, True, False)
+  return check_all(output, True, False, True, False, False)
 
 def test_astral(pargenes_script):
   basename = get_basename(pargenes_script)
@@ -199,7 +199,7 @@ def test_astral(pargenes_script):
   command += "-s 3 -p 3 "
   command += "--use-astral "
   run_command(command, "astral_" + basename, output)
-  return check_all(output, True, False, False, True)
+  return check_all(output, True, False, False, True, False)
 
 def test_aster(pargenes_script):
   # Testfirst with default aster binary astral
@@ -218,7 +218,7 @@ def test_aster(pargenes_script):
   command += "-s 3 -p 3 "
   command += "--use-aster "
   run_command(command, "aster_" + basename, output)
-  return check_all(output, True, False, False, True)
+  return check_all(output, True, False, False, False, True)
 
 def test_all(pargenes_script):
   basename = get_basename(pargenes_script)
@@ -238,7 +238,7 @@ def test_all(pargenes_script):
   command += "--use-astral "
   command += " --modeltest-global-parameters " + example_modeltest_parameters
   run_command(command, "all_" + basename, output)
-  return  check_all(output, True, True, True, True)
+  return  check_all(output, True, True, True, True, False)
 
 def test_all_aster(pargenes_script):
   basename = get_basename(pargenes_script)
@@ -258,7 +258,7 @@ def test_all_aster(pargenes_script):
   command += "--use-aster "
   command += " --modeltest-global-parameters " + example_modeltest_parameters
   run_command(command, "all_aster_" + basename, output)
-  return  check_all(output, True, True, True, True)
+  return  check_all(output, True, True, True, False, True)
 
 try:
   os.makedirs(tests_output_dir)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -6,10 +6,9 @@ import time
 import shlex
 import platform
 
-
 run_as_binary = "--run-as-binary" in sys.argv
 
-tests_path = os.path.dirname(os.path.realpath(__file__)) 
+tests_path = os.path.dirname(os.path.realpath(__file__))
 root = os.path.dirname(tests_path)
 pargenes_script_names = ["pargenes.py", "pargenes-hpc.py", "pargenes-hpc-debug.py"]
 pargenes_scripts = []
@@ -46,9 +45,9 @@ def check_parse(run_dir):
 
 def check_modeltest(run_dir):
   modeltest_dir = os.path.join(run_dir, "modeltest_run")
-  assert len(os.listdir(os.path.join(modeltest_dir, "running_jobs"))) == 0 
+  assert len(os.listdir(os.path.join(modeltest_dir, "running_jobs"))) == 0
   mlsearch_dir = os.path.join(run_dir, "mlsearch_run")
-  assert len(os.listdir(os.path.join(mlsearch_dir, "running_jobs"))) == 0  
+  assert len(os.listdir(os.path.join(mlsearch_dir, "running_jobs"))) == 0
   for msa, best_model in list(zip(valid_msas, best_models)):
     results = os.path.join(modeltest_dir, "results", msa)
     assert os.path.isdir(results)
@@ -59,10 +58,9 @@ def check_modeltest(run_dir):
     model = open(bestModel).readlines()[0].split(",")[0].split("{")[0]
     assert model == best_model
 
-
 def check_ml_search(run_dir):
   mlsearch_dir = os.path.join(run_dir, "mlsearch_run")
-  assert len(os.listdir(os.path.join(mlsearch_dir, "running_jobs"))) == 0  
+  assert len(os.listdir(os.path.join(mlsearch_dir, "running_jobs"))) == 0
   for msa in valid_msas:
     results = os.path.join(mlsearch_dir, "results", msa)
     prefix = os.path.join(results, msa + ".raxml.")
@@ -75,14 +73,14 @@ def check_astral(run_dir):
   astral_dir = os.path.join(run_dir, "astral_run")
   input_gene_trees = os.path.join(astral_dir, "gene_trees.newick")
   output_species_tree = os.path.join(astral_dir, "output_species_tree.newick")
-  assert(os.path.isfile(output_species_tree))
+  assert(os.path.isfile(input_gene_trees))
   assert(os.path.isfile(output_species_tree))
   input_gene_trees_lines = open(input_gene_trees).readlines()
   assert(len(input_gene_trees_lines) == 4)
   output_species_tree_str = open(output_species_tree).readlines()[0]
   for i in range(0, 10):
     assert(("taxa_" + str(i)) in output_species_tree_str)
-  
+
 def check_all(run_dir, parse, modeltest, mlsearch, astral):
   try:
     if (parse):
@@ -210,8 +208,6 @@ def test_all(pargenes_script):
   run_command(command, "all_" + basename, output)
   return  check_all(output, True, True, True, True)
 
-
-
 try:
   os.makedirs(tests_output_dir)
 except:
@@ -232,6 +228,4 @@ if (failures > 0):
   sys.exit(1)
 else:
   print("All tests ran successfully")
-
-
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -17,6 +17,7 @@ if (run_as_binary):
 else:
   for s in pargenes_script_names:
     pargenes_scripts.append("python " + os.path.join(root, "pargenes", s))
+
 example_data_path = os.path.join(tests_path, "smalldata")
 example_msas = os.path.join(example_data_path, "fasta_files")
 example_raxml_options = os.path.join(example_data_path, "raxml_global_options.txt")
@@ -82,7 +83,7 @@ def check_astral(run_dir):
     assert(("taxa_" + str(i)) in output_species_tree_str)
 
 def check_aster(run_dir):
-  astral_dir = os.path.join(run_dir, "aster_run")
+  aster_dir = os.path.join(run_dir, "aster_run")
   input_gene_trees = os.path.join(aster_dir, "gene_trees.newick")
   output_species_tree = os.path.join(aster_dir, "output_species_tree.newick")
   assert(os.path.isfile(input_gene_trees))

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -182,7 +182,7 @@ def test_bootstraps(pargenes_script):
   command += "-r " + example_raxml_options + " "
   command += "-c 4 "
   command += " -b 3"
-  run_command(command, "bootstraps" + basename, output)
+  run_command(command, "bootstraps_" + basename, output)
   return check_all(output, True, False, True, False, False)
 
 def test_astral(pargenes_script):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -81,7 +81,19 @@ def check_astral(run_dir):
   for i in range(0, 10):
     assert(("taxa_" + str(i)) in output_species_tree_str)
 
-def check_all(run_dir, parse, modeltest, mlsearch, astral):
+def check_aster(run_dir):
+  astral_dir = os.path.join(run_dir, "aster_run")
+  input_gene_trees = os.path.join(aster_dir, "gene_trees.newick")
+  output_species_tree = os.path.join(aster_dir, "output_species_tree.newick")
+  assert(os.path.isfile(input_gene_trees))
+  assert(os.path.isfile(output_species_tree))
+  input_gene_trees_lines = open(input_gene_trees).readlines()
+  assert(len(input_gene_trees_lines) == 4)
+  output_species_tree_str = open(output_species_tree).readlines()[0]
+  for i in range(0, 10):
+    assert(("taxa_" + str(i)) in output_species_tree_str)
+
+def check_all(run_dir, parse, modeltest, mlsearch, astral, aster):
   try:
     if (parse):
       check_parse(run_dir)
@@ -91,6 +103,8 @@ def check_all(run_dir, parse, modeltest, mlsearch, astral):
       check_ml_search(run_dir)
     if (astral):
       check_astral(run_dir)
+    if (aster):
+      check_aster(run_dir)
   except:
     print("FAILURE!!!!")
     return 1
@@ -98,7 +112,6 @@ def check_all(run_dir, parse, modeltest, mlsearch, astral):
   return 0
 
 def run_command(command, run_name, outputdir):
-  #print(command)
   logs = os.path.join(tests_output_dir, run_name + ".txt")
   sys.stdout.write("[" + run_name + "]: ")
   sys.stdout.flush()
@@ -188,6 +201,25 @@ def test_astral(pargenes_script):
   run_command(command, "astral_" + basename, output)
   return check_all(output, True, False, False, True)
 
+def test_aster(pargenes_script):
+  # Testfirst with default aster binary astral
+  # TODO: test with astral-hybrid and astral-pro
+  basename = get_basename(pargenes_script)
+  output = os.path.join(tests_output_dir, "test_aster", basename)
+  try:
+    shutil.rmtree(output)
+  except:
+    pass
+  command = pargenes_script + " "
+  command += "-a " + example_msas + " "
+  command += "-o " + output + " "
+  command += "-r " + example_raxml_options + " "
+  command += "-c 4 "
+  command += "-s 3 -p 3 "
+  command += "--use-aster "
+  run_command(command, "aster_" + basename, output)
+  return check_all(output, True, False, False, True)
+
 def test_all(pargenes_script):
   basename = get_basename(pargenes_script)
   output = os.path.join(tests_output_dir, "test_all", basename)
@@ -208,6 +240,26 @@ def test_all(pargenes_script):
   run_command(command, "all_" + basename, output)
   return  check_all(output, True, True, True, True)
 
+def test_all_aster(pargenes_script):
+  basename = get_basename(pargenes_script)
+  output = os.path.join(tests_output_dir, "test_all", basename)
+  try:
+    shutil.rmtree(output)
+  except:
+    pass
+  command = pargenes_script + " "
+  command += "-a " + example_msas + " "
+  command += "-o " + output + " "
+  command += "-r " + example_raxml_options + " "
+  command += "-c 4 "
+  command += "-m "
+  command += "-b 3 "
+  command += "-s 3 -p 3 "
+  command += "--use-aster "
+  command += " --modeltest-global-parameters " + example_modeltest_parameters
+  run_command(command, "all_aster_" + basename, output)
+  return  check_all(output, True, True, True, True)
+
 try:
   os.makedirs(tests_output_dir)
 except:
@@ -220,7 +272,9 @@ for pargenes_script in pargenes_scripts:
   failures += test_model_test(pargenes_script)
   failures += test_bootstraps(pargenes_script)
   failures += test_astral(pargenes_script)
+  failures += test_aster(pargenes_script)
   failures += test_all(pargenes_script)
+  failures += test_all_aster(pargenes_script)
 
 print("")
 if (failures > 0):

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -2,4 +2,4 @@ bindir="pargenes/pargenes_binaries"
 rm -rf MPIScheduler/build
 rm -rf raxml-ng/build
 rm -rf modeltest/build
-rm -rf $bindir/*
+rm -rf "${bindir:?}/"*


### PR DESCRIPTION
Add the the new ["ASTER"-suite](https://github.com/chaoszhang/ASTER) as alternatives to ASTRAL for species-tree reconstruction.

The branch adds options `--use-aster`, `--aster-global-parameters`, and `--aster-bin`, where the
argument to `--aster-bin` is the name of the binary (astral, astral-pro, astral-hybrid) or the path to a local binary. Default binary (no `--aster-bin`) is `astral`.

Code also tries to check for a `lib` folder if the `--astral-jar` option is used.

Minor style edits in files affected by the additions, but I've left the others as they are.

No changes have yet been made in the ParGenes wiki for documentation. Thought it could wait until a decision to add aster or not have been made?